### PR TITLE
Enable beman-tidy v0.5.1 in default mode

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the config file for beman-tidy, which checks compliance with the Beman Standard (https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+# Check documentation for beman-tidy here:
+# https://github.com/bemanproject/beman-tidy/blob/main/README.md
+
+disabled_rules:
+    # None
+ignored_paths:
+    - infra/

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
@@ -39,4 +40,11 @@ repos:
     hooks:
       - id: codespell
 
-exclude: 'cookiecutter/|infra/'
+  # Beman Standard checking via beman-tidy
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.5.1
+    hooks:
+      - id: beman-tidy
+        args: [".", "--verbose"]
+
+exclude: 'infra/'

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-<!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/map/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/map/actions/workflows/pre-commit-check.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+<!-- markdownlint-disable line-length -->
+[![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#the-beman-library-maturity-model)
+![Continuous Integration Tests](https://github.com/bemanproject/map/actions/workflows/ci_tests.yml/badge.svg)
+![Lint Check (pre-commit)](https://github.com/bemanproject/map/actions/workflows/pre-commit-check.yml/badge.svg)
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+<!-- markdownlint-restore -->
 
 `beman.map` implements safer, non-throwing map lookups returning `optional<T&>` instead
 of throwing (`.at()`) or silently inserting (`operator[]`).


### PR DESCRIPTION
## Summary
- Add beman-tidy v0.5.1 pre-commit hook in default mode (requirements only, no `--require-all`)
- Add `.beman-tidy.yaml` with `ignored_paths: [infra/]`
- Fix default-mode requirement violations: linked library status badge in README, SPDX license IDs in workflow/config files

Closes bemanproject/beman-tidy#333

## Root cause of CI "crash" (exit 2)
The [beman-tidy run on all libraries](https://github.com/bemanproject/beman-tidy/actions/runs/28735461609) reported map as "crashed" with exit code 2. This was **not** a beman-tidy Python crash — exit code 2 means **2 failed requirement checks**:
1. `readme.badges` — library status badge must use the v0.5.1 linked format (`[![Library Status](...)](...)`), not plain `![Library Status](...)`
2. `file.license_id` — missing SPDX headers in `.github/workflows/pre-commit-check.yml`, `.markdownlint.yaml`, and `.pre-commit-config.yaml` (plus infra files scanned because no `.beman-tidy.yaml` existed yet)

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [ ] CI pre-commit check passes on PR

Made with [Cursor](https://cursor.com)